### PR TITLE
Add ElectrsD::with_conf

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ useful in integration testing environment.
 
 ```
 let bitcoind = bitcoind::BitcoinD::new("/usr/local/bin/bitcoind").unwrap();
-let electrsd = electrsd::ElectrsD::new("/usr/local/bin/electrsd", bitcoind, false, false).unwrap();
+let electrsd = electrsd::ElectrsD::new("/usr/local/bin/electrsd", bitcoind).unwrap();
 let header = electrsd.client.block_headers_subscribe().unwrap();
 assert_eq!(header.height, 0);
 ```


### PR DESCRIPTION
Same as https://github.com/RCasatta/bitcoind/pull/7.
With this branch I was able to use ElectrsD with elementsd and electrs compiled with `--features liquid`.
If this is merged we can add this crate as dev dependency to GDK.