### PR TITLE
Remove zip dependency time feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ env_logger = "0.9"
 
 [build-dependencies]
 bitcoin_hashes = "0.10"
-zip = "0.5"
+zip = {version = "0.5", default-features = false, features = ["bzip2", "deflate"] }
 ureq = "2.1"
 
 [features]


### PR DESCRIPTION
The zip time feature is not used by this project and is currently causing the below audit check to fail.

Crate: time
Version: 0.1.43
Title: Potential segfault in the time crate
Date: 2020-11-18
ID: RUSTSEC-2020-0071
URL: https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution: Upgrade to >=0.2.23