### PR TITLE
Implement std::error::Error for crate::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,14 @@ impl Drop for ElectrsD {
     }
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for Error {}
+
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         Error::Io(e)


### PR DESCRIPTION
Making the crate's Error type `std::Error` helps in propagating them easier in downstream application.

Example
```
fn some_func(bitcoind: &electrsd::bitcoind::Bitcoind) -> Result<(), Box<dyn std::error::Error>> {
    ... do something
    let bitcoind = electrsd::bitcoind::BitcoinD::with_conf(bitcoind_exe, &bitcoind_conf)?;
    OK(())
}
```
This will the work.

Depends on https://github.com/RCasatta/bitcoind/pull/44
