### PR TITLE
Add configurable workdir options

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -12,14 +12,12 @@ jobs:
       RUST_LOG: debug
     strategy:
       matrix:
-        features: ["bitcoind_22_0,electrs_0_8_10", "bitcoind_22_0,electrs_0_9_1", "bitcoind_22_0,trigger,electrs_0_8_10"]
+        features: ["bitcoind_22_0,electrs_0_8_10", "bitcoind_22_0,electrs_0_9_1"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1.2.0
-        with:
-          key: ${{ contains(matrix.features, 'trigger') }} # key can't contain commas...
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 bitcoind = { version = "0.25.0" }
 electrum-client = { version="0.8.0", default-features = false }
-nix = { version="0.22.0", optional = true }
+nix = { version="0.22.0" }
 log = "0.4"
 
 [dev-dependencies]
@@ -23,7 +23,6 @@ zip = {version = "0.5", default-features = false, features = ["bzip2", "deflate"
 ureq = "2.1"
 
 [features]
-trigger = ["nix"]
 legacy = []
 
 esplora_a33e97e1 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,6 @@ pub enum Error {
     /// Wrapper of bitcoincore_rpc Error
     BitcoinCoreRpc(bitcoind::bitcoincore_rpc::Error),
 
-    #[cfg(feature = "trigger")]
     /// Wrapper of nix Error
     Nix(nix::Error),
 
@@ -222,7 +221,6 @@ impl ElectrsD {
         })
     }
 
-    #[cfg(feature = "trigger")]
     /// triggers electrs sync by sending the `SIGUSR1` signal, useful to call after a block for example
     pub fn trigger(&self) -> Result<(), Error> {
         Ok(nix::sys::signal::kill(
@@ -275,7 +273,6 @@ impl From<bitcoind::bitcoincore_rpc::Error> for Error {
     }
 }
 
-#[cfg(feature = "trigger")]
 impl From<nix::Error> for Error {
     fn from(e: nix::Error) -> Self {
         Error::Nix(e)
@@ -312,7 +309,6 @@ mod test {
         let address = bitcoind.client.get_new_address(None, None).unwrap();
         bitcoind.client.generate_to_address(100, &address).unwrap();
 
-        #[cfg(feature = "trigger")]
         electrsd.trigger().unwrap();
 
         let header = loop {


### PR DESCRIPTION
Fixes #35 

Replay the same changes of https://github.com/RCasatta/bitcoind/pull/52 for `electrs` index directory.

I couldn't figure a good way to stop the `electrs` server. So right now the `drop` is same as before. I am not entirely sure if that's total safe.. Looking or suggestions.. 