### PR TITLE
Update electrum-client to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 bitcoind = { version = "0.26.0" }
-electrum-client = { version="0.10.0", default-features = false }
+electrum-client = { version="0.11.0", default-features = false }
 nix = { version="0.22.0" }
 log = "0.4"
 


### PR DESCRIPTION
This is the last release of electrum-client before bumping rust-bitcoin to 0.29

It includes the recent fixes and some API improvements that I wanted to make available to projects using 0.28 (like bdk).