### PR TITLE
bump version to 0.21, bump deps (bitcoin 0.29)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrsd"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest electrs process, useful in integration testing environment"
 repository = "https://github.com/RCasatta/electrsd"
@@ -9,9 +9,9 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-bitcoind = { version = "0.26.0" }
-electrum-client = { version="0.11.0", default-features = false }
-nix = { version="0.22.0" }
+bitcoind = { version = "0.27.0" }
+electrum-client = { version="0.12.0", default-features = false }
+nix = { version="0.25.0" }
 log = "0.4"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,13 +429,7 @@ mod test {
 
     fn init() -> (String, String) {
         let _ = env_logger::try_init();
-        let bitcoind_exe_path = if let Ok(env_bitcoind_exe) = env::var("BITCOIND_EXE") {
-            env_bitcoind_exe
-        } else if let Ok(downloaded_exe_path) = bitcoind::downloaded_exe_path() {
-            downloaded_exe_path
-        } else {
-            panic!("when no version feature is specified, you must specify BITCOIND_EXE env var")
-        };
+        let bitcoind_exe_path = bitcoind::exe_path().unwrap();
         let electrs_exe_path = if let Ok(env_electrs_exe) = env::var("ELECTRS_EXE") {
             env_electrs_exe
         } else if let Some(downloaded_exe_path) = crate::downloaded_exe_path() {


### PR DESCRIPTION
bumps bitcoind, electrum-client and nix deps