### PR TITLE
Bump zip dependency to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ env_logger = "0.9"
 
 [build-dependencies]
 bitcoin_hashes = "0.10"
-zip = {version = "0.5", default-features = false, features = ["bzip2", "deflate"] }
+zip = {version = "0.6", default-features = false, features = ["bzip2", "deflate"] }
 ureq = "2.1"
 
 [features]


### PR DESCRIPTION
Even though we disabled the `time` feature in #23, cargo audit is still flagging this vulnerability. The fixed version of `zip` 0.6 is out now and includes an update to the fixed `time` dependency, see zip-rs/zip#254. 

```
Crate:     time
Version:   0.1.44
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── zip 0.5.13
    ├── electrsd 0.21.1
    │   └── bdk 0.23.0
    └── bitcoind 0.27.1
        └── electrsd 0.21.1
```