### PR TITLE
Re-export `electrum_client`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ use std::time::Duration;
 
 // re-export bitcoind
 pub use bitcoind;
+// re-export electrum_client because calling RawClient methods requires the ElectrumApi trait
+pub use electrum_client;
 
 /// Electrs configuration parameters, implements a convenient [Default] for most common use.
 ///


### PR DESCRIPTION
Without the reexport, downstream users have to additionally declare the `electrum_client` crate in their `Cargo.toml` if they want to be able to use the methods defined by the `ElectrumApi` trait.