### PR TITLE
Replace `ureq` with `minreq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = "0.9"
 [build-dependencies]
 bitcoin_hashes = "0.11"
 zip = { version = "0.6", default-features = false, features = ["bzip2", "deflate"] }
-ureq = "2.1"
+minreq = { version = "2.6.0", default-features = false, features = ["https"] }
 
 [features]
 legacy = []

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use bitcoin_hashes::{sha256, Hash};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Cursor, Read};
+use std::io::{BufRead, BufReader, Cursor};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::str::FromStr;
@@ -43,14 +43,8 @@ fn main() {
         );
 
         let url = format!("{}/{}", GITHUB_URL, download_filename);
-        let mut downloaded_bytes = Vec::new();
 
-        let _size = ureq::get(&url)
-            .call()
-            .unwrap()
-            .into_reader()
-            .read_to_end(&mut downloaded_bytes)
-            .unwrap();
+        let downloaded_bytes = minreq::get(url).send().unwrap().into_bytes();
 
         let downloaded_hash = sha256::Hash::hash(&downloaded_bytes);
         assert_eq!(expected_hash, downloaded_hash);


### PR DESCRIPTION
Multiple projects in the `rust-bitcoin` space are currently planning a migration away from `ureq` to `minreq`, as it provides better MSRV guarantees.

In this PR we trivially replace the `ureq` dependency by `minreq`. Note that this doesn't necessarily lower the MSRV right away due to the included `rustls` dependency, but is a preparatory step.

Also see https://github.com/RCasatta/bitcoind/pull/110.