### PR TITLE
feat: optional download

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       CARGO_TERM_COLOR: always
+      ELECTRS_EXEC: "/home/runner/.cargo-install/electrs/bin/electrs"
     steps:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install electrs
@@ -56,6 +57,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: electrs
+      - run: "echo $ELECTRS_EXEC"
       - name: Checkout Crate
         uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -44,6 +44,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --features ${{ matrix.features }}
 
+  test-electrs-no-download:
+    name: Test Electrs no auto-download features
+    runs-on: ubuntu-20.04
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install electrs
+        # Automatically cache installed binaries to avoid compiling them each run
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: electrs
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --features 'bitcoind/25_0'
 
   cosmetics:
     runs-on: ubuntu-20.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrsd"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest electrs process, useful in integration testing environment"
 repository = "https://github.com/RCasatta/electrsd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,31 +12,41 @@ categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 [dependencies]
 bitcoind = { version = "0.33.0" }
 electrum-client = { version = "0.15.0", default-features = false }
-nix = { version="0.25.0" }
+nix = { version = "0.25.0" }
 log = "0.4"
+which = "4.2.5"
 
 [dev-dependencies]
 env_logger = "0.10"
 
 [build-dependencies]
-bitcoin_hashes = "0.12"
-zip = { version = "0.6", default-features = false, features = ["bzip2", "deflate"] }
-minreq = { version = "2.9.0", default-features = false, features = ["https"] }
+bitcoin_hashes = { version = "0.12", optional = true }
+zip = { version = "0.6", default-features = false, optional = true, features = [
+  "bzip2",
+  "deflate",
+] }
+minreq = { version = "2.9.0", default-features = false, optional = true, features = [
+  "https",
+] }
 
 [features]
 legacy = []
 
-esplora_a33e97e1 = []
-electrs_0_8_10 = []
-electrs_0_9_1 = []
-electrs_0_9_11 = []
+# download is not supposed to be used directly only through selecting one of the version feature
+download = ["bitcoin_hashes", "zip", "minreq"]
 
-bitcoind_25_0 = ["bitcoind/25_0"]
-bitcoind_24_0_1 = ["bitcoind/24_0_1"]
-bitcoind_23_1 = ["bitcoind/23_1"]
-bitcoind_22_1 = ["bitcoind/22_1"]
-bitcoind_0_21_2 = ["bitcoind/0_21_2"]
-bitcoind_0_20_2 = ["bitcoind/0_20_2"]
-bitcoind_0_19_1 = ["bitcoind/0_19_1"]
-bitcoind_0_18_1 = ["bitcoind/0_18_1"]
-bitcoind_0_17_1 = ["bitcoind/0_17_1"]
+
+esplora_a33e97e1 = ["download"]
+electrs_0_8_10 = ["download"]
+electrs_0_9_1 = ["download"]
+electrs_0_9_11 = ["download"]
+
+bitcoind_25_0 = ["download", "bitcoind/25_0"]
+bitcoind_24_0_1 = ["download", "bitcoind/24_0_1"]
+bitcoind_23_1 = ["download", "bitcoind/23_1"]
+bitcoind_22_1 = ["download", "bitcoind/22_1"]
+bitcoind_0_21_2 = ["download", "bitcoind/0_21_2"]
+bitcoind_0_20_2 = ["download", "bitcoind/0_20_2"]
+bitcoind_0_19_1 = ["download", "bitcoind/0_19_1"]
+bitcoind_0_18_1 = ["download", "bitcoind/0_18_1"]
+bitcoind_0_17_1 = ["download", "bitcoind/0_17_1"]

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ assert_eq!(header.height, 0);
 ## Automatic binaries download
 
 In your project Cargo.toml, activate the following features
+
 ```yml
 electrsd = { version= "0.23", features = ["bitcoind_23_1", "electrs_0_9_1"] }
 ```
+
 Then use it:
+
 ```rust
 let bitcoind_exe = bitcoind::downloaded_exe_path().expect("bitcoind version feature must be enabled");
 let bitcoind = bitcoind::BitcoinD::new(bitcoind_exe).unwrap();
@@ -29,6 +32,19 @@ let electrsd = electrsd::ElectrsD::new(electrs_exe, bitcoind).unwrap();
 
 When the `ELECTRSD_DOWNLOAD_ENDPOINT`/`BITCOIND_DOWNLOAD_ENDPOINT` environment variables are set,
 `electrsd`/`bitcoind` will try to download the binaries from the given endpoints.
+
+When you don't use the auto-download feature you have the following options:
+
+- have `electrs` executable in the `PATH`
+- provide the `electrs` executable via the `ELECTRS_EXEC` env var
+
+```rust
+if let Ok(exe_path) = electrsd::exe_path() {
+  let electrsd = electrsd::electrsD::new(exe_path).unwrap();
+}
+```
+
+Startup options could be configured via the `Conf` struct using `electrsD::with_conf` or `electrsD::from_downloaded_with_conf`.
 
 ## Issues with traditional approach
 
@@ -45,11 +61,17 @@ I used integration testing based on external bash script launching needed extern
   * A free port is asked to the OS (a very low probability race condition is still possible) 
   * The process is killed when the struct goes out of scope no matter how the test finishes
   * Automatically download `electrs` executable with enabled features. Since there are no official binaries, they are built using the [manual workflow](.github/workflows/build_electrs.yml) under this project. Supported version are:
+    * [electrs 0.9.11](https://github.com/romanz/electrs/releases/tag/v0.9.11) (feature=electrs_0_9_11)
     * [electrs 0.9.1](https://github.com/romanz/electrs/releases/tag/v0.9.1) (feature=electrs_0_9_1)
     * [electrs 0.8.10](https://github.com/romanz/electrs/releases/tag/v0.8.10) (feature=electrs_0_8_10)
     * [electrs esplora](https://github.com/Blockstream/electrs/tree/a33e97e1a1fc63fa9c20a116bb92579bbf43b254) (feature=esplora_a33e97e1)
 
 Thanks to these features every `#[test]` could easily run isolated with its own environment
+
+## Deprecations
+
+- Starting from version `0.26` the env var `ELECTRS_EXE` is deprecated in favor of `ELECTRS_EXEC`.
+
 
 ## Used by
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ assert_eq!(header.height, 0);
 
 In your project Cargo.toml, activate the following features
 ```yml
-electrsd = { version= "0.23", features = ["bitcoind_23_0", "electrs_0_9_1"] }
+electrsd = { version= "0.23", features = ["bitcoind_23_1", "electrs_0_9_1"] }
 ```
 Then use it:
 ```rust

--- a/build.rs
+++ b/build.rs
@@ -1,67 +1,79 @@
-use bitcoin_hashes::{sha256, Hash};
-use std::fs::File;
-use std::io::{BufRead, BufReader, Cursor};
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
-use std::str::FromStr;
+#[cfg(not(feature = "download"))]
+fn main() {}
 
-include!("src/versions.rs");
-
-const GITHUB_URL: &str = "https://github.com/RCasatta/electrsd/releases/download/electrs_releases";
-
-fn get_expected_sha256(filename: &str) -> Result<sha256::Hash, ()> {
-    let file = File::open("sha256").map_err(|_| ())?;
-    for line in BufReader::new(file).lines().flatten() {
-        let tokens: Vec<_> = line.split("  ").collect();
-        if tokens.len() == 2 && filename == tokens[1] {
-            return sha256::Hash::from_str(tokens[0]).map_err(|_| ());
-        }
-    }
-    Err(())
+#[cfg(feature = "download")]
+fn main() {
+    download::download()
 }
 
-fn main() {
-    if !HAS_FEATURE {
-        return;
+#[cfg(feature = "download")]
+mod download {
+    use bitcoin_hashes::{sha256, Hash};
+    use std::fs::File;
+    use std::io::{BufRead, BufReader, Cursor};
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use std::str::FromStr;
+
+    include!("src/versions.rs");
+
+    const GITHUB_URL: &str =
+        "https://github.com/RCasatta/electrsd/releases/download/electrs_releases";
+
+    fn get_expected_sha256(filename: &str) -> Result<sha256::Hash, ()> {
+        let file = File::open("sha256").map_err(|_| ())?;
+        for line in BufReader::new(file).lines().flatten() {
+            let tokens: Vec<_> = line.split("  ").collect();
+            if tokens.len() == 2 && filename == tokens[1] {
+                return sha256::Hash::from_str(tokens[0]).map_err(|_| ());
+            }
+        }
+        Err(())
     }
-    let download_filename_without_extension = electrs_name();
-    let download_filename = format!("{}.zip", download_filename_without_extension);
-    dbg!(&download_filename);
-    let expected_hash = get_expected_sha256(&download_filename).unwrap();
-    let out_dir = std::env::var_os("OUT_DIR").unwrap();
-    let electrs_exe_home = Path::new(&out_dir).join("electrs");
-    let destination_filename = electrs_exe_home
-        .join(&download_filename_without_extension)
-        .join("electrs");
 
-    dbg!(&destination_filename);
+    pub fn download() {
+        if !HAS_FEATURE {
+            return;
+        }
+        let download_filename_without_extension = electrs_name();
+        let download_filename = format!("{}.zip", download_filename_without_extension);
+        dbg!(&download_filename);
+        let expected_hash = get_expected_sha256(&download_filename).unwrap();
+        let out_dir = std::env::var_os("OUT_DIR").unwrap();
+        let electrs_exe_home = Path::new(&out_dir).join("electrs");
+        let destination_filename = electrs_exe_home
+            .join(&download_filename_without_extension)
+            .join("electrs");
 
-    if !destination_filename.exists() {
-        println!(
-            "filename:{} version:{} hash:{}",
-            download_filename, VERSION, expected_hash
-        );
+        dbg!(&destination_filename);
 
-        let download_endpoint =
-            std::env::var("ELECTRSD_DOWNLOAD_ENDPOINT").unwrap_or(GITHUB_URL.to_string());
-        let url = format!("{}/{}", download_endpoint, download_filename);
+        if !destination_filename.exists() {
+            println!(
+                "filename:{} version:{} hash:{}",
+                download_filename, VERSION, expected_hash
+            );
 
-        let downloaded_bytes = minreq::get(url).send().unwrap().into_bytes();
+            let download_endpoint =
+                std::env::var("ELECTRSD_DOWNLOAD_ENDPOINT").unwrap_or(GITHUB_URL.to_string());
+            let url = format!("{}/{}", download_endpoint, download_filename);
 
-        let downloaded_hash = sha256::Hash::hash(&downloaded_bytes);
-        assert_eq!(expected_hash, downloaded_hash);
-        let cursor = Cursor::new(downloaded_bytes);
+            let downloaded_bytes = minreq::get(url).send().unwrap().into_bytes();
 
-        let mut archive = zip::ZipArchive::new(cursor).unwrap();
-        let mut file = archive.by_index(0).unwrap();
-        std::fs::create_dir_all(destination_filename.parent().unwrap()).unwrap();
-        let mut outfile = std::fs::File::create(&destination_filename).unwrap();
+            let downloaded_hash = sha256::Hash::hash(&downloaded_bytes);
+            assert_eq!(expected_hash, downloaded_hash);
+            let cursor = Cursor::new(downloaded_bytes);
 
-        std::io::copy(&mut file, &mut outfile).unwrap();
-        std::fs::set_permissions(
-            &destination_filename,
-            std::fs::Permissions::from_mode(0o755),
-        )
-        .unwrap();
+            let mut archive = zip::ZipArchive::new(cursor).unwrap();
+            let mut file = archive.by_index(0).unwrap();
+            std::fs::create_dir_all(destination_filename.parent().unwrap()).unwrap();
+            let mut outfile = std::fs::File::create(&destination_filename).unwrap();
+
+            std::io::copy(&mut file, &mut outfile).unwrap();
+            std::fs::set_permissions(
+                &destination_filename,
+                std::fs::Permissions::from_mode(0o755),
+            )
+            .unwrap();
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,10 @@ pub enum Error {
 
     /// Returned when both tmpdir and staticdir is specified in `Conf` options
     BothDirsSpecified,
+
+    /// Returned when calling methods requiring the bitcoind executable but none is found
+    /// (no feature, no `ELECTRS_EXEC`, no `electrs` in `PATH` )
+    NoElectrsExecutableFound,
 }
 
 impl std::error::Error for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
     /// Returned when calling methods requiring the bitcoind executable but none is found
     /// (no feature, no `ELECTRS_EXEC`, no `electrs` in `PATH` )
     NoElectrsExecutableFound,
+
+    /// Returned if both env vars `ELECTRS_EXEC` and `ELECTRS_EXE` are found
+    BothEnvVars,
 }
 
 impl std::error::Error for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,12 +411,12 @@ mod test {
     fn init() -> (String, String) {
         let _ = env_logger::try_init();
         let bitcoind_exe_path = bitcoind::exe_path().unwrap();
-        let electrs_exe_path = if let Ok(env_electrs_exe) = env::var("ELECTRS_EXE") {
+        let electrs_exe_path = if let Ok(env_electrs_exe) = env::var("ELECTRS_EXEC") {
             env_electrs_exe
         } else if let Some(downloaded_exe_path) = crate::downloaded_exe_path() {
             downloaded_exe_path
         } else {
-            panic!("when no version feature is specified, you must specify ELECTRS_EXE env var")
+            panic!("when no version feature is specified, you must specify ELECTRS_EXEC env var")
         };
         (bitcoind_exe_path, electrs_exe_path)
     }


### PR DESCRIPTION
- bump version to `0.26.0`
- normalize ENV vars as the same prefix `bitcoind`: `ELECTRS_EXE` -> `ELECTRS_EXEC`
- optionally download when building to allow Nix builds
- fix missnamed feature in `README.md`: `bitcoind_23_0` -> `bitcoind_23_1`
- introduces `which` to find executables
- introduces CI to test without auto-download features

This makes a Nix CI pass, check: https://github.com/realeinherjar/bdk/actions/runs/6512925971/job/17691535222 (ignore the failed ones, MSRV, I am still working on those)

- Closes #68