### PR TITLE
define OS as undefined when neither linux nor macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrsd"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest electrs process, useful in integration testing environment"
 repository = "https://github.com/RCasatta/electrsd"

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -27,7 +27,7 @@ impl ElectrsD {
                 Ok(tx) => {
                     // having the raw tx doesn't mean the scripts has been indexed
                     let txid = tx.txid();
-                    if let Some(output) = tx.output.get(0) {
+                    if let Some(output) = tx.output.first() {
                         let history = self
                             .client
                             .script_get_history(&output.script_pubkey)

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -4,6 +4,9 @@ const OS: &str = "macos";
 #[cfg(target_os = "linux")]
 const OS: &str = "linux";
 
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+const OS: &str = "undefined";
+
 #[cfg(feature = "electrs_0_8_10")]
 const VERSION: &str = "v0.8.10";
 


### PR DESCRIPTION
Otherwise an errors is thrown during an NDK build which should in theory not need dev-dependcies but it does