### PR TITLE
Upgrade to `electrum-client` v0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 
 [dependencies]
 bitcoind = { version = "0.36.0" }
-electrum-client = { version = "0.20.0", default-features = false }
+electrum-client = { version = "0.21.0", default-features = false }
 log = { version = "0.4" }
 which = { version = "4.2.5" }
 


### PR DESCRIPTION
The `electrum-client` crate released v0.21 recently. It would be great to upgrade and get a release out to enable compatibility of `ElectrumApi` for crates that already upgraded (such as LDK). 

(cc @RCasatta)