### PR TITLE
Build electrs 0.10.6

### DIFF
--- a/.github/workflows/build_electrs.yml
+++ b/.github/workflows/build_electrs.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-11]
+        os: [ubuntu-24.04, macos-15]
     env:
       ELECTRS_TAG: "v0.9.11"
 

--- a/.github/workflows/build_electrs.yml
+++ b/.github/workflows/build_electrs.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15]
     env:
-      ELECTRS_TAG: "v0.9.11"
+      ELECTRS_TAG: "v0.10.6"
 
     steps:
       - name: Check out Electrs

--- a/.github/workflows/build_electrs.yml
+++ b/.github/workflows/build_electrs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: downcase runner.os
         run: echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]' | echo RUNNER_OS_LOWER=$(</dev/stdin) >>${GITHUB_ENV}
       - name: Upload libs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: electrs_${{ env.RUNNER_OS_LOWER }}_${{ env.ELECTRS_TAG }}
           path: target/release/electrs


### PR DESCRIPTION
This is to build electrs v0.10.6, which is the most recent tag.

I was able to run this updated workflow here: https://github.com/jp1ac4/electrsd/actions/runs/11542187543.

I can add a corresponding electrs_0_10_6 feature too if you like.