### PR TITLE
Re-export `corepc_node`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-// re-export bitcoind
+// re-export corepc_node
+pub use corepc_node;
+// re-export corepc_client
 pub use corepc_client;
 // re-export electrum_client because calling RawClient methods requires the ElectrumApi trait
 pub use electrum_client;


### PR DESCRIPTION
When upgrading to `corepc_node`, the re-export of `bitcoind` was replaced with a re-export of `corepc-client`. While the latter can still be useful, still exporting the whole `corepc_node` might be good to allow users accessing exactly the `corepc_node` version referenced by `electrsd`.