### PR TITLE
Upgrade the corepc crate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 
 [dependencies]
-corepc-node = { version = "0.5.0", default-features = false }
-corepc-client = { version = "0.5.0" }
+corepc-node = { version = "0.6.1", features = ["download"] }
+corepc-client = { version = "0.6.1" }
 electrum-client = { version = "0.22.0", default-features = false }
 log = { version = "0.4" }
 which = { version = "4.2.5" }


### PR DESCRIPTION
Upgrade to the latest version of the corepc crates.

I'm going to leave this on draft to see if #95 goes in, just because I did it on top of that originally.