### PR TITLE
CI: Add a job to test a few versions of the corepc crates

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -19,6 +19,26 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build
 
+  corepc-node-versions:
+    name: Test a bunch of corepc-node versions.
+    runs-on: ubuntu-24.04
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_LOG: debug
+    strategy:
+      matrix:
+        features:
+          - corepc-node_27_2,electrs_0_10_6
+          - corepc-node_26_2,electrs_0_10_6
+          - corepc-node_25_2,electrs_0_10_6
+          - corepc-node_24_2,electrs_0_10_6
+          - corepc-node_23_1,electrs_0_10_6
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --features ${{ matrix.features }}
 
   test-electrs:
     name: Test Electrs


### PR DESCRIPTION
Don't bother doing all of them just do the lastest 5 excluding 28_0 because it doesn't work here right now - needs further debugging.

Also do 0_17_1 because its the default now in `corepc-node` so running `cargo build` in this crate implicitly uses that feature.


Fix: #97