### PR TITLE
Bump `corepc` crates to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 
 [dependencies]
-corepc-node = { version = "0.6.1" }
-corepc-client = { version = "0.6.1" }
+corepc-node = { version = "0.7.0" }
+corepc-client = { version = "0.7.0" }
 electrum-client = { version = "0.22.0", default-features = false }
 log = { version = "0.4" }
 which = { version = "4.2.5" }


### PR DESCRIPTION
.. which were just released and features some bugfixes we require to run it in our CI.