### PR TITLE
Bump `electrum-client` version to 0.23.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 [dependencies]
 corepc-node = { version = "0.7.0" }
 corepc-client = { version = "0.7.0" }
-electrum-client = { version = "0.22.0", default-features = false }
+electrum-client = { version = "0.23.1", default-features = false }
 log = { version = "0.4" }
 which = { version = "4.2.5" }
 


### PR DESCRIPTION
We bump the `electrum-client` dependency to the recently released version 0.23.1.

This is important to establish compatibility in preparation for the upcoming BDK 2.0 release, which we're looking to upgrade to ASAP. 

@RCasatta as usual, a release for this would be much appreciated!