### PR TITLE
Bump corepc crates to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 
 [dependencies]
-corepc-node = { version = "0.7.0" }
-corepc-client = { version = "0.7.0" }
+corepc-node = { version = "0.8.0" }
+corepc-client = { version = "0.8.0" }
 electrum-client = { version = "0.23.1", default-features = false }
 log = { version = "0.4" }
 which = { version = "4.2.5" }
@@ -44,7 +44,8 @@ electrs_0_9_1 = ["download"]
 electrs_0_9_11 = ["download"]
 electrs_0_10_6 = ["download"]
 
-corepc-node_28_0 = ["corepc-node/download", "corepc-node/28_0"]
+corepc-node_29_0 = ["corepc-node/download", "corepc-node/29_0"]
+corepc-node_28_1 = ["corepc-node/download", "corepc-node/28_1"]
 corepc-node_27_2 = ["corepc-node/download", "corepc-node/27_2"]
 corepc-node_26_2 = ["corepc-node/download", "corepc-node/26_2"]
 corepc-node_25_2 = ["corepc-node/download", "corepc-node/25_2"]
@@ -55,4 +56,4 @@ corepc-node_0_21_2 = ["corepc-node/download", "corepc-node/0_21_2"]
 corepc-node_0_20_2 = ["corepc-node/download", "corepc-node/0_20_2"]
 corepc-node_0_19_1 = ["corepc-node/download", "corepc-node/0_19_1"]
 corepc-node_0_18_1 = ["corepc-node/download", "corepc-node/0_18_1"]
-corepc-node_0_17_1 = ["corepc-node/download", "corepc-node/0_17_1"]
+corepc-node_0_17_2 = ["corepc-node/download", "corepc-node/0_17_2"]


### PR DESCRIPTION
Bump the version of the corepc-node to `v0.8.0`. This release includes upgraded Core versions, fix features as required.