### PR TITLE
Bump `electrum-client` to v0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 [dependencies]
 corepc-node = { version = "0.8.0" }
 corepc-client = { version = "0.8.0" }
-electrum-client = { version = "0.23.1", default-features = false }
+electrum-client = { version = "0.24.0", default-features = false }
 log = { version = "0.4" }
 which = { version = "4.2.5" }
 


### PR DESCRIPTION
We bump the `electrum-client` dependency to the recently-introduced version v0.24.0.

@RCasatta As we'll need this to unbreak our CI after bumping the client version ourselves, it would be great if `electrsd` could cut a release for this!