### PR TITLE
Add integration tests for Core `v28.1v and `v29.0`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -28,6 +28,8 @@ jobs:
     strategy:
       matrix:
         features:
+          - corepc-node_29_0,electrs_0_10_6
+          - corepc-node_28_1,electrs_0_10_6
           - corepc-node_27_2,electrs_0_10_6
           - corepc-node_26_2,electrs_0_10_6
           - corepc-node_25_2,electrs_0_10_6


### PR DESCRIPTION
The `0.8.0` release of `corepc-node` supports Core versions `v28.1` and `v29.0` but we never added integration tests for them.