### PR TITLE
Upgrade `corepc-node` to `v.0.9.0`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         features:
           - corepc-node_29_0,electrs_0_10_6
-          - corepc-node_28_1,electrs_0_10_6
+          - corepc-node_28_2,electrs_0_10_6
           - corepc-node_27_2,electrs_0_10_6
           - corepc-node_26_2,electrs_0_10_6
           - corepc-node_25_2,electrs_0_10_6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 
 [dependencies]
-corepc-node = { version = "0.8.0" }
-corepc-client = { version = "0.8.0" }
+corepc-node = { version = "0.9.0" }
+corepc-client = { version = "0.9.0" }
 electrum-client = { version = "0.24.0", default-features = false }
 log = { version = "0.4" }
 which = { version = "4.2.5" }
@@ -45,7 +45,7 @@ electrs_0_9_11 = ["download"]
 electrs_0_10_6 = ["download"]
 
 corepc-node_29_0 = ["corepc-node/download", "corepc-node/29_0"]
-corepc-node_28_1 = ["corepc-node/download", "corepc-node/28_1"]
+corepc-node_28_2 = ["corepc-node/download", "corepc-node/28_2"]
 corepc-node_27_2 = ["corepc-node/download", "corepc-node/27_2"]
 corepc-node_26_2 = ["corepc-node/download", "corepc-node/26_2"]
 corepc-node_25_2 = ["corepc-node/download", "corepc-node/25_2"]


### PR DESCRIPTION
Update to the latest `corepc-node` release. This release added support for Core `v28.2` so we update the relevant feature and add an integration test for `v28.2` and `v29.0`.
