### PR TITLE
testing the code in the README.md

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,13 @@ pub fn exe_path() -> anyhow::Result<String> {
         .map(|p| p.display().to_string())
 }
 
+// Test the code in the readme
+#[doc = include_str!("../README.md")]
+#[allow(dead_code)]
+fn readme() {
+    // dummy function
+}
+
 #[cfg(test)]
 mod test {
     use crate::exe_path;


### PR DESCRIPTION
* Adapted the code sections in the readme to reflect the move from bitcoind to corepc-node.
* Having the code sections in the readme tested when running "cargo test"

I don't think the cargo fmt failure in the CI is related to my changes.

#closes https://github.com/RCasatta/electrsd/issues/107